### PR TITLE
Add CSV and JSON parsers

### DIFF
--- a/datamax/parser/csv_parser.py
+++ b/datamax/parser/csv_parser.py
@@ -1,10 +1,31 @@
-from datamax.parser.base import MarkdownOutputVo
+import pandas as pd
+
+from datamax.parser.base import BaseLife, MarkdownOutputVo
 
 
-class CsvParser:
+class CsvParser(BaseLife):
 
-    def __init__(self, filename):
-        self.filename = filename
+    def __init__(self, file_path):
+        super().__init__()
+        self.file_path = file_path
 
-    def parse(self) -> MarkdownOutputVo:
-        pass
+    @staticmethod
+    def read_csv_file(file_path: str) -> pd.DataFrame:
+        """Read a CSV file into a pandas DataFrame."""
+        return pd.read_csv(file_path)
+
+    def parse(self, file_path: str) -> MarkdownOutputVo:
+        try:
+            df = self.read_csv_file(file_path)
+            mk_content = df.to_markdown(index=False)
+            lifecycle = self.generate_lifecycle(
+                source_file=file_path,
+                domain="Technology",
+                usage_purpose="Documentation",
+                life_type="LLM_ORIGIN",
+            )
+            output_vo = MarkdownOutputVo(self.get_file_extension(file_path), mk_content)
+            output_vo.add_lifecycle(lifecycle)
+            return output_vo.to_dict()
+        except Exception as e:
+            raise e

--- a/datamax/parser/json_parser.py
+++ b/datamax/parser/json_parser.py
@@ -1,10 +1,32 @@
-from datamax.parser.base import MarkdownOutputVo
+import json
+
+from datamax.parser.base import BaseLife, MarkdownOutputVo
 
 
-class Parser:
+class JsonParser(BaseLife):
 
     def __init__(self, file_path):
+        super().__init__()
         self.file_path = file_path
 
-    def parse(self) -> MarkdownOutputVo:
-        pass
+    @staticmethod
+    def read_json_file(file_path: str) -> str:
+        """Read and pretty print a JSON file."""
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return json.dumps(data, indent=2, ensure_ascii=False)
+
+    def parse(self, file_path: str) -> MarkdownOutputVo:
+        try:
+            content = self.read_json_file(file_path)
+            lifecycle = self.generate_lifecycle(
+                source_file=file_path,
+                domain="Technology",
+                usage_purpose="Documentation",
+                life_type="LLM_ORIGIN",
+            )
+            output_vo = MarkdownOutputVo(self.get_file_extension(file_path), content)
+            output_vo.add_lifecycle(lifecycle)
+            return output_vo.to_dict()
+        except Exception as e:
+            raise e

--- a/tests/test_csv_parser.py
+++ b/tests/test_csv_parser.py
@@ -1,0 +1,17 @@
+import sys
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from datamax.parser.csv_parser import CsvParser
+
+def test_csv_parser(tmp_path):
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("a,b\n1,2\n3,4\n", encoding="utf-8")
+    parser = CsvParser(file_path=str(csv_file))
+    result = parser.parse(file_path=str(csv_file))
+    assert result["title"] == "csv"
+    assert "a" in result["content"]
+    assert result["lifecycle"][0]["life_metadata"]["source_file"] == str(csv_file)
+

--- a/tests/test_json_parser.py
+++ b/tests/test_json_parser.py
@@ -1,0 +1,18 @@
+import json
+import sys
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from datamax.parser.json_parser import JsonParser
+
+def test_json_parser(tmp_path):
+    json_file = tmp_path / "data.json"
+    json_file.write_text(json.dumps({"a": 1, "b": 2}), encoding="utf-8")
+    parser = JsonParser(file_path=str(json_file))
+    result = parser.parse(file_path=str(json_file))
+    assert result["title"] == "json"
+    assert "\"a\"" in result["content"]
+    assert result["lifecycle"][0]["life_metadata"]["source_file"] == str(json_file)
+


### PR DESCRIPTION
## Summary
- implement `CsvParser.parse` to return MarkdownOutputVo
- implement `JsonParser.parse` to return MarkdownOutputVo
- add simple unit tests for both parsers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684078649d28832b871d970b8c2cc7ae