### PR TITLE
refactor(parser): 统一使用 extension 代替 title，并同步测试Refactor/extension only

### DIFF
--- a/datamax/parser/base.py
+++ b/datamax/parser/base.py
@@ -37,8 +37,8 @@ class MarkdownOutputVo:
     Markdown output conversion
     """
 
-    def __init__(self, title: str, content: str):
-        self.title: str = title  # File type
+    def __init__(self, extension: str, content: str):
+        self.extension: str = extension  # File type
         self.content: str = content  # Markdown content
         self.lifecycle: List[LifeCycle] = []  # Life cycle data
 
@@ -47,7 +47,7 @@ class MarkdownOutputVo:
 
     def to_dict(self):
         data_dict = {
-            'title': self.title,
+            'extension': self.extension,
             'content': self.content,
             'lifecycle': [lc.to_dict() for lc in self.lifecycle]
         }

--- a/datamax/parser/doc_parser.py
+++ b/datamax/parser/doc_parser.py
@@ -584,9 +584,9 @@ class DocParser(BaseLife):
             if file_size == 0:
                 logger.warning(f"⚠️ 文件大小为0字节: {file_path}")
 
-            # 🏷️ 提取文件标题（改用扩展名）
-            title = self.get_file_extension(file_path)
-            logger.debug(f"🏷️ 提取文件标题: {title}")
+            # 🏷️ 提取文件扩展名
+            extension = self.get_file_extension(file_path)
+            logger.debug(f"🏷️ 提取文件扩展名: {extension}")
 
             # 读取文件内容
             logger.info("📝 读取DOC文件内容")
@@ -615,7 +615,7 @@ class DocParser(BaseLife):
             )
             logger.debug("⚙️ 生成lifecycle信息完成")
 
-            output_vo = MarkdownOutputVo(title, mk_content)
+            output_vo = MarkdownOutputVo(extension, mk_content)
             output_vo.add_lifecycle(lifecycle)
 
             result = output_vo.to_dict()

--- a/datamax/parser/doc_parser.py
+++ b/datamax/parser/doc_parser.py
@@ -584,7 +584,8 @@ class DocParser(BaseLife):
             if file_size == 0:
                 logger.warning(f"⚠️ 文件大小为0字节: {file_path}")
 
-            title = os.path.splitext(os.path.basename(file_path))[0]
+            # 🏷️ 提取文件标题（改用扩展名）
+            title = self.get_file_extension(file_path)
             logger.debug(f"🏷️ 提取文件标题: {title}")
 
             # 读取文件内容

--- a/datamax/parser/docx_parser.py
+++ b/datamax/parser/docx_parser.py
@@ -723,7 +723,8 @@ class DocxParser(BaseLife):
             if file_size == 0:
                 logger.warning(f"⚠️ 文件大小为0字节: {file_path}")
 
-            title = os.path.splitext(os.path.basename(file_path))[0]
+            # 🏷️ 提取文件标题（改用扩展名）
+            title = self.get_file_extension(file_path)
             logger.debug(f"🏷️ 提取文件标题: {title}")
 
             # 使用soffice转换为txt后读取内容

--- a/datamax/parser/docx_parser.py
+++ b/datamax/parser/docx_parser.py
@@ -723,9 +723,9 @@ class DocxParser(BaseLife):
             if file_size == 0:
                 logger.warning(f"⚠️ 文件大小为0字节: {file_path}")
 
-            # 🏷️ 提取文件标题（改用扩展名）
-            title = self.get_file_extension(file_path)
-            logger.debug(f"🏷️ 提取文件标题: {title}")
+            # 🏷️ 提取文件扩展名
+            extension = self.get_file_extension(file_path)
+            logger.debug(f"🏷️ 提取文件扩展名: {extension}")
 
             # 使用soffice转换为txt后读取内容
             logger.info("📝 使用soffice转换DOCX为TXT并读取内容")
@@ -754,7 +754,7 @@ class DocxParser(BaseLife):
             )
             logger.debug("⚙️ 生成lifecycle信息完成")
 
-            output_vo = MarkdownOutputVo(title, mk_content)
+            output_vo = MarkdownOutputVo(extension, mk_content)
             output_vo.add_lifecycle(lifecycle)
 
             result = output_vo.to_dict()

--- a/datamax/parser/epub_parser.py
+++ b/datamax/parser/epub_parser.py
@@ -29,12 +29,12 @@ class EpubParser(BaseLife):
 
     def parse(self, file_path: str) -> MarkdownOutputVo:
         try:
-            title = os.path.splitext(os.path.basename(file_path))[0]
+            extension = self.get_file_extension(file_path)
             content = self.read_epub_file(file_path=file_path)
             mk_content = content
             lifecycle = self.generate_lifecycle(source_file=file_path, domain="Technology",
                                                 usage_purpose="Documentation", life_type="LLM_ORIGIN")
-            output_vo = MarkdownOutputVo(title, mk_content)
+            output_vo = MarkdownOutputVo(extension, mk_content)
             output_vo.add_lifecycle(lifecycle)
             return output_vo.to_dict()
         except Exception as e:

--- a/datamax/parser/html_parser.py
+++ b/datamax/parser/html_parser.py
@@ -26,12 +26,12 @@ class HtmlParser(BaseLife):
 
     def parse(self, file_path: str) -> MarkdownOutputVo:
         try:
-            title = os.path.splitext(os.path.basename(file_path))[0]
+            extension = self.get_file_extension(file_path)
             content = self.read_html_file(file_path=file_path)
             mk_content = content
             lifecycle = self.generate_lifecycle(source_file=file_path, domain="Technology",
                                                 usage_purpose="Documentation", life_type="LLM_ORIGIN")
-            output_vo = MarkdownOutputVo(title, mk_content)
+            output_vo = MarkdownOutputVo(extension, mk_content)
             output_vo.add_lifecycle(lifecycle)
             return output_vo.to_dict()
         except Exception:

--- a/datamax/parser/md_parser.py
+++ b/datamax/parser/md_parser.py
@@ -50,7 +50,7 @@ class MarkdownParser(BaseLife):
             MarkdownOutputVo: Structured output containing the markdown content
         """
         try:
-            title = os.path.splitext(os.path.basename(file_path))[0]
+            extension = self.get_file_extension(file_path)
 
             # Read markdown content
             md_content = self.read_markdown_file(file_path)
@@ -64,7 +64,7 @@ class MarkdownParser(BaseLife):
             )
 
             # Create and return output VO
-            output_vo = MarkdownOutputVo(title, md_content)
+            output_vo = MarkdownOutputVo(extension, md_content)
             output_vo.add_lifecycle(lifecycle)
             return output_vo.to_dict()
 

--- a/datamax/parser/pdf_parser.py
+++ b/datamax/parser/pdf_parser.py
@@ -69,7 +69,7 @@ class PdfParser(BaseLife):
 
     def parse(self, file_path: str) -> MarkdownOutputVo:
         try:
-            title = os.path.splitext(os.path.basename(file_path))[0]
+            extension = self.get_file_extension(file_path)
 
             if self.use_mineru:
                 output_dir = 'uploaded_files'
@@ -94,7 +94,7 @@ class PdfParser(BaseLife):
 
             lifecycle = self.generate_lifecycle(source_file=file_path, domain="Technology",
                                                 usage_purpose="Documentation", life_type="LLM_ORIGIN")
-            output_vo = MarkdownOutputVo(title, mk_content)
+            output_vo = MarkdownOutputVo(extension, mk_content)
             output_vo.add_lifecycle(lifecycle)
             return output_vo.to_dict()
         except Exception:

--- a/datamax/parser/ppt_parser.py
+++ b/datamax/parser/ppt_parser.py
@@ -107,7 +107,7 @@ class PPtParser(BaseLife):
 
     def parse(self, file_path: str) -> MarkdownOutputVo:
         try:
-            title = os.path.splitext(os.path.basename(file_path))[0]
+            extension = self.get_file_extension(file_path)
             content = self.read_ppt_file(file_path=file_path)
             # clean_text = clean_original_text(content)
             mk_content = content
@@ -117,7 +117,7 @@ class PPtParser(BaseLife):
                 usage_purpose="Documentation",
                 life_type="LLM_ORIGIN",
             )
-            output_vo = MarkdownOutputVo(title, mk_content)
+            output_vo = MarkdownOutputVo(extension, mk_content)
             output_vo.add_lifecycle(lifecycle)
             return output_vo.to_dict()
         except Exception:

--- a/datamax/parser/pptx_parser.py
+++ b/datamax/parser/pptx_parser.py
@@ -33,12 +33,12 @@ class PPtxParser(BaseLife):
 
     def parse(self, file_path: str) -> MarkdownOutputVo:
         try:
-            title = os.path.splitext(os.path.basename(file_path))[0]
+            extension = self.get_file_extension(file_path)
             content = self.read_ppt_file(file_path=file_path)
             mk_content = content
             lifecycle = self.generate_lifecycle(source_file=file_path, domain="Technology",
                                                 usage_purpose="Documentation", life_type="LLM_ORIGIN")
-            output_vo = MarkdownOutputVo(title, mk_content)
+            output_vo = MarkdownOutputVo(extension, mk_content)
             output_vo.add_lifecycle(lifecycle)
             return output_vo.to_dict()
         except Exception:

--- a/datamax/parser/txt_parser.py
+++ b/datamax/parser/txt_parser.py
@@ -34,12 +34,12 @@ class TxtParser(BaseLife):
 
     def parse(self, file_path: str) -> MarkdownOutputVo:
         try:
-            title = os.path.splitext(os.path.basename(file_path))[0]
+            extension = self.get_file_extension(file_path)
             content = self.read_txt_file(file_path=file_path)  # 真实数据是从load加载
             mk_content = content
             lifecycle = self.generate_lifecycle(source_file=file_path, domain="Technology",
                                                 usage_purpose="Documentation", life_type="LLM_ORIGIN")
-            output_vo = MarkdownOutputVo(title, mk_content)
+            output_vo = MarkdownOutputVo(extension, mk_content)
             output_vo.add_lifecycle(lifecycle)
             return output_vo.to_dict()
         except Exception as e:

--- a/datamax/parser/xlsx_parser.py
+++ b/datamax/parser/xlsx_parser.py
@@ -129,8 +129,8 @@ class XlsxParser(BaseLife):
             logger.debug("⚙️ 生成lifecycle信息完成")
 
             # 创建输出对象
-            title = os.path.splitext(os.path.basename(file_path))[0]
-            output_vo = MarkdownOutputVo(title, mk_content)
+            extension = self.get_file_extension(file_path)
+            output_vo = MarkdownOutputVo(extension, mk_content)
             output_vo.add_lifecycle(lifecycle)
 
             result = output_vo.to_dict()

--- a/tests/test_doc_parser.py
+++ b/tests/test_doc_parser.py
@@ -144,7 +144,7 @@ class TestDocParser:
             
             result = parser.parse("test.doc")
             
-            assert result["title"] == "doc"
+            assert result["extension"] == "doc"
             assert result["content"] == "文档内容测试"
             assert "lifecycle" in result
             mock_read.assert_called_once_with(doc_path="test.doc")
@@ -174,7 +174,7 @@ class TestDocParser:
             
             result = parser.parse("test.doc")
             
-            assert result["title"] == "doc"
+            assert result["extension"] == "doc"
             assert result["content"] == "标题\n内容"  # format_as_markdown在这种情况下保持原样
             assert "lifecycle" in result
 
@@ -204,7 +204,7 @@ class TestDocParser:
         with patch.object(parser, 'read_doc_file', return_value="这是一个测试文档\n包含多行内容"):
             result = parser.parse(str(doc_file))
             
-            assert result["title"] == "doc"
+            assert result["extension"] == "doc"
             assert "这是一个测试文档" in result["content"]
             assert result["lifecycle"][0]["life_metadata"]["source_file"] == str(doc_file)
 

--- a/tests/test_docx_parser.py
+++ b/tests/test_docx_parser.py
@@ -144,7 +144,7 @@ class TestDocxParser:
             
             result = parser.parse("test.docx")
             
-            assert result["title"] == "docx"
+            assert result["extension"] == "docx"
             assert result["content"] == "DOCX文档内容测试"
             assert "lifecycle" in result
             mock_read.assert_called_once_with(docx_path="test.docx")
@@ -174,7 +174,7 @@ class TestDocxParser:
             
             result = parser.parse("test.docx")
             
-            assert result["title"] == "docx"
+            assert result["extension"] == "docx"
             assert result["content"] == "DOCX标题\n内容段落"  # format_as_markdown在这种情况下保持原样
             assert "lifecycle" in result
 
@@ -202,7 +202,7 @@ class TestDocxParser:
             
             # 应该仍然能够解析，只是会有警告
             result = parser.parse("test.txt")
-            assert result["title"] == "txt"
+            assert result["extension"] == "txt"
 
     @patch('datamax.parser.docx_parser.os.path.exists')
     @patch('datamax.parser.docx_parser.os.path.getsize')
@@ -227,7 +227,7 @@ class TestDocxParser:
             mock_lifecycle.return_value = mock_lifecycle_obj
             
             result = parser.parse("empty.docx")
-            assert result["title"] == "docx"
+            assert result["extension"] == "docx"
             assert result["content"] == ""
 
     def test_format_as_markdown(self):
@@ -256,7 +256,7 @@ class TestDocxParser:
         with patch.object(parser, 'read_docx_file', return_value="这是一个测试DOCX文档\n包含多行内容"):
             result = parser.parse(str(docx_file))
             
-            assert result["title"] == "docx"
+            assert result["extension"] == "docx"
             assert "这是一个测试DOCX文档" in result["content"]
             assert result["lifecycle"][0]["life_metadata"]["source_file"] == str(docx_file)
 


### PR DESCRIPTION
### 本次改动

- 各解析器中：
  - 原先 `title = os.path.splitext(...)[0]` 改为 `extension = self.get_file_extension(...)`
  - 原先 `MarkdownOutputVo(title, content)` 改为 `MarkdownOutputVo(extension, content)`
- 更新 `MarkdownOutputVo` 构造和 `to_dict()`，把返回键 `"title"` 改成 `"extension"`。
- 同步修改所有单元测试，从 `result["title"]` → `result["extension"]`。

#### 验证

```bash
$ python -m pytest -q
..................................
=== 34 passed in 1.04s ===

