### PR TITLE
Fix README.md example variable name and add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ test.py
 # venv
 venv/
 venv*/
+.venv/
 examples/parser_examples.py
 # scripts
 security_report.json

--- a/README.md
+++ b/README.md
@@ -52,9 +52,8 @@ qa_data = dm.get_pre_label(
     question_number=5,     # 每块生成问题数
     max_workers=5          # 并发数
 )
-dm.save_label_data(res)
+dm.save_label_data(qa_data)      # Save the tagging data returned by the pre tagging process
 ```
-
 ## 📖 Detailed Documentation
 
 ### File Parsing


### PR DESCRIPTION
## 更改描述
Fixed the variable naming error in the AI annotation section of the README.md sample code.
.gitignore supplements. venv/to prevent virtual environments from being mistakenly added to version control.

## 更改类型
- [ ] Bug修复
- [ ] 新功能
- [ ] 重大更改（会破坏现有功能）
- [x] 文档更新
- [ ] 代码重构
- [ ] 性能优化
- [ ] 测试添加/修改

## 测试
- [ ] 已添加相应的测试
- [ ] 所有测试通过
- [x] 已手动测试相关功能

## 检查清单
- [x] 代码遵循项目的代码规范
- [x] 已进行自我代码审查
- [x] 代码已添加适当的注释
- [x] 已更新相关文档
- [x] 更改不会产生新的警告
- [ ] 已添加相应的测试且测试通过
- [ ] 新依赖项（如有）已记录在requirements.txt中

## 相关Issue
关闭 #(issue编号)
